### PR TITLE
Improved splitting threshold calculation

### DIFF
--- a/PRF/PRF.py
+++ b/PRF/PRF.py
@@ -271,7 +271,7 @@ class RandomForestClassifier:
 
         return new_class_proba
 
-    def predict_single_tree(self, predict, X, dX, out, lock):
+    def predict_single_tree(self, predict, X, dX, out):
 
         # let all the trees vote - the function pick_best find the best class from each tree, and gives zero probability to all the others
         #prediction = numpy.vstack([self.pick_best(predict(x, dx)) for x, dx in zip(X,dX)])
@@ -281,14 +281,13 @@ class RandomForestClassifier:
 
         #print(prediction[:10])
 
-        with lock:
-            if len(out) == 1:
-                out[0] += prediction
-                #out2[0] += prediction[1]
-            else:
-                for i in range(len(out)):
-                    out[i] += prediction[i]
-                    #out2[i] += prediction[i][1]
+        if len(out) == 1:
+            out[0] += prediction
+            #out2[0] += prediction[1]
+        else:
+            for i in range(len(out)):
+                out[i] += prediction[i]
+                #out2[i] += prediction[i][1]
 
     def predict_proba(self, X, dX=None):
         """
@@ -298,7 +297,6 @@ class RandomForestClassifier:
         proba = numpy.zeros((X.shape[0], self.n_classes_), dtype=numpy.float64)
         #Parallel(n_jobs=-1,  backend="threading")(delayed(tree.node_arr_init)
         #                       () for tree in self.estimators_)
-        lock = threading.Lock()
         #Parallel(n_jobs=-1, verbose = 10, backend="threading")(delayed(self.predict_single_tree)
         #                       (tree.predict_proba, X, dX, all_proba,  lock) for tree in self.estimators_)
 
@@ -306,7 +304,7 @@ class RandomForestClassifier:
 
         for i, tree in enumerate(self.estimators_):
             tree.node_arr_init()
-            self.predict_single_tree(tree.predict_proba, X, dX, proba,  lock)
+            self.predict_single_tree(tree.predict_proba, X, dX, proba)
 
         proba /= self.n_estimators_
 

--- a/PRF/PRF.py
+++ b/PRF/PRF.py
@@ -19,7 +19,8 @@ class DecisionTreeClassifier:
     """
     This the the decision tree classifier class.
     """
-    def __init__(self, criterion='gini', max_features=None, use_py_gini = True, use_py_leafs = True, max_depth = None, keep_proba = 0.05, unsupervised=False, new_syn_data_frac=0):
+    def __init__(self, criterion='gini', max_features=None, use_py_gini = True, use_py_leafs = True, max_depth = None,
+                 keep_proba = 0.05, unsupervised=False, new_syn_data_frac=0, min_py_sum_leaf=1):
         self.criterion = criterion
         self.max_features = max_features
         self.use_py_gini = use_py_gini
@@ -29,6 +30,7 @@ class DecisionTreeClassifier:
         self.is_node_arr_init = False
         self.unsupervised = unsupervised
         self.new_syn_data_frac = new_syn_data_frac
+        self.min_py_sum_leaf = min_py_sum_leaf
 
     def get_nodes(self):
 
@@ -110,7 +112,7 @@ class DecisionTreeClassifier:
             py_leafs = py_flat
         depth = 0
 
-        self.tree_ = tree.fit_tree(X, pX, py_gini, py_leafs, pnode, depth, is_max, self.max_depth, self.max_features, self.feature_importances_, self.n_samples_, self.keep_proba, self.unsupervised, self.new_syn_data_frac)
+        self.tree_ = tree.fit_tree(X, pX, py_gini, py_leafs, pnode, depth, is_max, self.max_depth, self.max_features, self.feature_importances_, self.n_samples_, self.keep_proba, self.unsupervised, self.new_syn_data_frac, self.min_py_sum_leaf)
 
 
     def predict_proba(self, X, dX, return_leafs=False):
@@ -132,7 +134,8 @@ class DecisionTreeClassifier:
 ############################################################
 
 class RandomForestClassifier:
-    def __init__(self, n_estimators=10, criterion='gini', max_features='auto', use_py_gini = True, use_py_leafs = True, max_depth = None, keep_proba = 0.05, bootstrap=True, new_syn_data_frac=0):
+    def __init__(self, n_estimators=10, criterion='gini', max_features='auto', use_py_gini = True, use_py_leafs = True,
+                 max_depth = None, keep_proba = 0.05, bootstrap=True, new_syn_data_frac=0, min_py_sum_leaf=1):
         self.n_estimators_ = n_estimators
         self.criterion = criterion
         self.max_features = max_features
@@ -143,6 +146,7 @@ class RandomForestClassifier:
         self.keep_proba = keep_proba
         self.bootstrap = bootstrap
         self.new_syn_data_frac = new_syn_data_frac
+        self.min_py_sum_leaf = min_py_sum_leaf
 
     def check_input_X(self, X, dX):
 
@@ -179,7 +183,8 @@ class RandomForestClassifier:
                               max_depth = self.max_depth,
                               keep_proba = self.keep_proba,
                               unsupervised = self.unsupervised,
-                              new_syn_data_frac = self.new_syn_data_frac)
+                              new_syn_data_frac = self.new_syn_data_frac,
+                              min_py_sum_leaf=self.min_py_sum_leaf)
 
         if self.bootstrap:
             X_chosen, pX_chosen, py_chosen = self._choose_objects(X, pX, py)

--- a/PRF/PRF.py
+++ b/PRF/PRF.py
@@ -172,7 +172,6 @@ class RandomForestClassifier:
 
     def _fit_single_tree(self, X, pX, py):
 
-        numpy.random.seed()
         tree = DecisionTreeClassifier(criterion=self.criterion,
                               max_features=self.max_features_num,
                               use_py_gini = self.use_py_gini,

--- a/PRF/best_split.py
+++ b/PRF/best_split.py
@@ -14,6 +14,13 @@ from .  import misc_functions as m
 
 
 @jit(cache=True, nopython=True)
+def gini(class_p_arr):
+    normalization = class_p_arr.sum()
+    v = class_p_arr / normalization
+    impurity = numpy.sum(v * (1 - v))
+    return normalization, impurity
+
+@jit(cache=True, nopython=True)
 def _gini_init(py):
 
     nof_classes = py.shape[1]

--- a/PRF/best_split.py
+++ b/PRF/best_split.py
@@ -96,26 +96,26 @@ def get_best_split(X, py, current_score, features_chosen_indices, max_features):
     while (n_visited < max_features) or ((found_split == False) and (n_visited < n_features)):
         feature_index = features_chosen_indices[n_visited]
         n_visited = n_visited + 1
-    #for feature_index in features_chosen_indices:
 
-        # We first sort the feature values for the selected feature. This allows us to avoid spliting the sample in each
-        # iteration. Instead we can just move one object
-        feature_values = X[:,feature_index].copy()
         # skip objects with nan values
-        nan_values = numpy.isnan(feature_values)
-        nof_objects_skip = nan_values.sum()
+        nan_indices = numpy.isnan(X[:, feature_index])
+        nof_objects_skip = nan_indices.sum()
         if nof_objects_skip == nof_objects:
             continue
 
-        feature_values[nan_values] = numpy.nanmax(feature_values) + 1
+        # We first sort the feature values for the selected feature. This allows us to avoid splitting the sample in
+        # each iteration. Instead we can just move one object
+        feature_values = X[~nan_indices, feature_index].copy()
+        py_sum_per_class_for_nans = py[nan_indices, :].sum(axis=0)
+        current_py = py[~nan_indices, :]
 
         x_asort = numpy.argsort(feature_values)
         x_sorted = feature_values[x_asort]
 
         # We calculate the impurity when all the objects are on the right node.
-        # in each iteration of loop over possible splits, we just update this value by moving one object to the other side of the
-        # split (using the _gini_update function).
-        impurity_right, normalization_right, class_p_right = _gini_init(py)
+        # In each iteration of loop over possible splits, we just update this value by moving one object to the other
+        # side of the split (using the _gini_update function).
+        impurity_right, normalization_right, class_p_right = _gini_init(current_py)
         impurity_left, normalization_left, class_p_left = 0, 0, 0*class_p_right
 
         nof_objects_itr = nof_objects - nof_objects_skip
@@ -129,28 +129,37 @@ def get_best_split(X, py, current_score, features_chosen_indices, max_features):
 
             move_idx = nof_objects_left - 1
             # Update the impurities on both sides
-            impurity_right, normalization_right, class_p_right  = _gini_update( normalization_right,  class_p_right, -py[x_asort[move_idx]])
-            impurity_left, normalization_left, class_p_left  = _gini_update( normalization_left, class_p_left, py[x_asort[move_idx]])
+            impurity_left, normalization_left, class_p_left = _gini_update(normalization_left, class_p_left,
+                                                                           current_py[x_asort[move_idx]])
+            impurity_right, normalization_right, class_p_right = _gini_update(normalization_right, class_p_right,
+                                                                              -current_py[x_asort[move_idx]])
 
             # if we have the same values for different objects we need to move all of them
-
             while (nof_objects_right >= 1) and isclose(x_sorted[move_idx],x_sorted[move_idx + 1]):
                 nof_objects_left += 1
                 nof_objects_right -= 1
                 move_idx = nof_objects_left - 1
-                # Update the impurities on both sides
-                impurity_right, normalization_right, class_p_right  = _gini_update( normalization_right,  class_p_right, -py[x_asort[move_idx]])
-                impurity_left, normalization_left, class_p_left  = _gini_update( normalization_left, class_p_left, py[x_asort[move_idx]])
 
+                # Update the impurities on both sides
+                impurity_left, normalization_left, class_p_left = _gini_update(normalization_left, class_p_left,
+                                                                               current_py[x_asort[move_idx]])
+                impurity_right, normalization_right, class_p_right = _gini_update(normalization_right, class_p_right,
+                                                                                  -current_py[x_asort[move_idx]])
+
+            # add the contribution of the NaN values (which are not among the nof_objects_itr elements)
+            p = class_p_left.sum() / (class_p_left.sum() + class_p_right.sum())
+            class_p_left_adjusted = class_p_left + p * py_sum_per_class_for_nans
+            class_p_right_adjusted = class_p_right + (1 - p) * py_sum_per_class_for_nans
+            normalization_left, impurity_left = gini(class_p_left_adjusted)
+            normalization_right, impurity_right = gini(class_p_right_adjusted)
 
             # Calculate the gain for the split
             normalization = normalization_right + normalization_left
-            p_right = normalization_right / normalization
             p_left = normalization_left / normalization
+            p_right = normalization_right / normalization
             gain = current_score - p_right*impurity_right - p_left*impurity_left
 
             # Check if this is a better gain that the current best gain
-            #print(nof_objects_right,  impurity_right, nof_objects_left,  impurity_left)
             if gain > best_gain:
                 found_split = True
 

--- a/PRF/best_split.py
+++ b/PRF/best_split.py
@@ -166,6 +166,9 @@ def get_best_split(X, py, current_score, features_chosen_indices, max_features):
                 # Save the values of the best split so far
                 best_gain = gain
                 best_attribute = feature_index
-                best_attribute_value = feature_values[x_asort[move_idx]]
+
+                if move_idx < (nof_objects - nof_objects_skip - 1):
+                    s = feature_values[x_asort[move_idx]] + feature_values[x_asort[move_idx + 1]]
+                    best_attribute_value = s / 2
 
     return  best_gain, best_attribute, best_attribute_value

--- a/PRF/best_split.py
+++ b/PRF/best_split.py
@@ -58,7 +58,10 @@ def _gini_update(normalization, class_p_arr, py):
         class_p_arr[class_idx] +=  py[class_idx]
 
         # fraction of class size
-        class_p = class_p_arr[class_idx]/normalization
+        if normalization != 0:  # avoid divide by zero (in case of an empty node)
+            class_p = class_p_arr[class_idx] / normalization
+        else:
+            class_p = 0
 
         # gini impurity
         impurity += class_p*(1-class_p)
@@ -112,11 +115,10 @@ def get_best_split(X, py, current_score, features_chosen_indices, max_features):
         nof_objects_right = nof_objects_itr
         nof_objects_left = 0
 
-        # In each iteration of this loop we move object by object from the left to the right side of the loop.
-        nof_objects_left += 1
-        nof_objects_right -= 1
-        while (nof_objects_right>0) and (nof_objects_left>0):
-        #for i in range(nof_objects_itr):
+        while nof_objects_right >= 1:
+            # In each iteration of this loop we move object by object from the left to the right side of the loop.
+            nof_objects_left += 1
+            nof_objects_right -= 1
 
             move_idx = nof_objects_left - 1
             # Update the impurities on both sides
@@ -125,7 +127,7 @@ def get_best_split(X, py, current_score, features_chosen_indices, max_features):
 
             # if we have the same values for different objects we need to move all of them
 
-            while isclose(x_sorted[move_idx],x_sorted[move_idx + 1]) and (nof_objects_right > 1):
+            while (nof_objects_right >= 1) and isclose(x_sorted[move_idx],x_sorted[move_idx + 1]):
                 nof_objects_left += 1
                 nof_objects_right -= 1
                 move_idx = nof_objects_left - 1
@@ -149,9 +151,5 @@ def get_best_split(X, py, current_score, features_chosen_indices, max_features):
                 best_gain = gain
                 best_attribute = feature_index
                 best_attribute_value = feature_values[x_asort[move_idx]]
-
-            # Update the number of objects in each side of the split
-            nof_objects_left += 1
-            nof_objects_right -= 1
 
     return  best_gain, best_attribute, best_attribute_value

--- a/PRF/tree.py
+++ b/PRF/tree.py
@@ -165,7 +165,7 @@ def fit_tree(X, dX, py_gini, py_leafs, pnode, depth, is_max, tree_max_depth, max
             th = 10*keep_proba
             if (numpy.sum(pnode_right) >= th) and (numpy.sum(pnode_left) >= th):
                 # add the impurity of the best split into the feature importance value
-                p = n_objects_node / tree_n_samples
+                p = scaled_py_gini.sum() / tree_n_samples
                 feature_importances[best_attribute] += p * best_gain
 
                 # Split all the arrays according to the indicies we have for the object in each side of the split

--- a/PRF/tree.py
+++ b/PRF/tree.py
@@ -116,7 +116,8 @@ def get_synthetic_data(X, dX, py, py_remove, pnode, is_max):
 
 
 
-def fit_tree(X, dX, py_gini, py_leafs, pnode, depth, is_max, tree_max_depth, max_features, feature_importances, tree_n_samples, keep_proba, unsupervised=False, new_syn_data_frac=0):
+def fit_tree(X, dX, py_gini, py_leafs, pnode, depth, is_max, tree_max_depth, max_features, feature_importances,
+             tree_n_samples, keep_proba, unsupervised=False, new_syn_data_frac=0, min_py_sum_leaf=1):
     """
     function grows a recursive disicion tree according to the objects X and their classifications y
     """
@@ -162,7 +163,7 @@ def fit_tree(X, dX, py_gini, py_leafs, pnode, depth, is_max, tree_max_depth, max
             pnode_right, pnode_left, best_right, best_left, is_max_right, is_max_left, pnode_right_tot = m.get_split_objects(pnode, p_split_right, p_split_left, is_max, n_objects_node, keep_proba)
 
             # Check if the best split is valid (that is not a useless 0-everything split)
-            th = 10*keep_proba
+            th = min_py_sum_leaf
             if (numpy.sum(pnode_right) >= th) and (numpy.sum(pnode_left) >= th):
                 # add the impurity of the best split into the feature importance value
                 p = scaled_py_gini.sum() / tree_n_samples
@@ -176,8 +177,8 @@ def fit_tree(X, dX, py_gini, py_leafs, pnode, depth, is_max, tree_max_depth, max
 
                 # go to the next steps of the recursive process
                 depth = depth + 1
-                right_branch = fit_tree(X_right, dX_right, py_right, py_leafs_right, pnode_right, depth, is_max_right, tree_max_depth, max_features, feature_importances, tree_n_samples, keep_proba, unsupervised, new_syn_data_frac)
-                left_branch  = fit_tree(X_left,  dX_left,  py_left,  py_leafs_left , pnode_left, depth, is_max_left, tree_max_depth, max_features, feature_importances, tree_n_samples, keep_proba, unsupervised, new_syn_data_frac)
+                right_branch = fit_tree(X_right, dX_right, py_right, py_leafs_right, pnode_right, depth, is_max_right, tree_max_depth, max_features, feature_importances, tree_n_samples, keep_proba, unsupervised, new_syn_data_frac, min_py_sum_leaf)
+                left_branch  = fit_tree(X_left,  dX_left,  py_left,  py_leafs_left , pnode_left, depth, is_max_left, tree_max_depth, max_features, feature_importances, tree_n_samples, keep_proba, unsupervised, new_syn_data_frac, min_py_sum_leaf)
 
                 return _tree(feature_index=best_attribute, feature_threshold=best_attribute_value, true_branch=right_branch, false_branch=left_branch, p_right=pnode_right_tot)
 


### PR DESCRIPTION
Major change: 
- spread the elements with missing values on both branches when computing the splitting threshold

Minor changes: 
- use the sum of objects' probabilities instead of their count when computing the contribution to the current feature importance
- use the average of the closest points as splitting threshold instead of the left point
- add a new hyperparameter (called _min_py_sum_leaf_) that controls the minimum sum of objects' probabilities to be at a leaf node (similar to Sklearn's hyperparameter _min_samples_leaf_)
- fix the seed for reproducibility